### PR TITLE
Use the prop-types package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* global window, document */
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'; 
 import cx from 'classnames';
 import debounce from './lib/debounce';
 


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated. 
Use the prop-types package from npm instead.